### PR TITLE
Fix React key collision when switching subtitle languages

### DIFF
--- a/components/subtitles.tsx
+++ b/components/subtitles.tsx
@@ -150,7 +150,7 @@ export function Subtitles() {
       {currSubtitles.state === 'loading' && <Loading />}
       <div style={{ overflow: 'auto' }} ref={subtitlesRef} aria-hidden onClick={handleSubtitleClick}>
         {events.map((event, i) => (
-          <Subtitle key={event.endMs} event={event} currentPlaying={i === index} />
+          <Subtitle key={event.endMs + event.vssId} event={event} currentPlaying={i === index} />
         ))}
       </div>
     </section>
@@ -169,7 +169,6 @@ const Subtitle = memo(
     return (
       <div
         className={bcls(style.subtitle, currentPlaying && style.currSubtitle, baseStyle.transitionColors)}
-        key={event.endMs}
         data-start-ms={event.startMs}
       >
         <div className={style.timestamp}>

--- a/utils/captionsAtom.ts
+++ b/utils/captionsAtom.ts
@@ -101,6 +101,7 @@ export interface subtitleEvent {
   endMs: number
   durMs: number
   content: string
+  vssId: string
 }
 interface Subtitle {
   events: subtitleEvent[]
@@ -148,6 +149,7 @@ const subtitlesBaseAtom = atom(async (get) => {
         endMs: event.tStartMs + event.dDurationMs,
         durMs: event.dDurationMs,
         content: event.segs.map((seg) => seg.utf8).join(' '),
+        vssId: caption.vssId,
       })
     })
 


### PR DESCRIPTION
- Add vssId to subtitleEvent interface for unique identification
- Use endMs + vssId as React key to prevent component reuse across languages
- Remove duplicate key prop from Subtitle component
- Ensures proper re-rendering when switching between different subtitle tracks

Fixes subtitle rendering issues where old content persisted after language changes.